### PR TITLE
match for colors without hash

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -33,7 +33,7 @@ end
 M.initStyleIds()
 
 M.extract_hex_colors = function(input_string)
-	local pattern = "#([0-9a-fA-F]+)"
+	local pattern = "#?([0-9a-fA-F]+)"
 	local matches = {}
 
 	local init = 1


### PR DESCRIPTION
Allows the ability for colors such as cc241d to be detected, since some configuration formats such as 0xcc241d or cc241d alone do not get detected.